### PR TITLE
Add user reservation limit

### DIFF
--- a/models/resource.rb
+++ b/models/resource.rb
@@ -13,6 +13,11 @@ class Resource < ActiveRecord::Base
 	has_many :resource_field_datas, dependent: :destroy
 	alias_method :approvers, :resource_approvers
 
+    def user_reservation_limit
+        # return nil unless valid limit
+        return max_reservations_per_user unless max_reservations_per_user.nil? || max_reservations_per_user.to_i < 1
+    end
+
 	def method_missing(meth_sym)
 		# check if this symbol can be associated with a field for this class
 		if !self.resource_class.nil? && (field = ResourceField.find_by(:resource_class_id => self.resource_class.id, :field_name => meth_sym.to_s.downcase))

--- a/routes/admin/tools.rb
+++ b/routes/admin/tools.rb
@@ -45,6 +45,7 @@ post '/admin/tools/create/?' do
 	tool.increment_minutes_per_reservation = params[:increment_minutes_per_reservation]
 	tool.needs_approval = false
 	tool.max_reservations_per_slot = 5
+	tool.max_reservations_per_user = params[:max_reservations_per_user]
 	tool.save
 	tool.set_field_data('model', params[:model])
 
@@ -87,6 +88,7 @@ post '/admin/tools/:resource_id/edit/?' do
 	tool.min_minutes_per_reservation = params[:min_minutes_per_reservation]
 	tool.max_minutes_per_reservation = params[:max_minutes_per_reservation]
 	tool.increment_minutes_per_reservation = params[:increment_minutes_per_reservation]
+	tool.max_reservations_per_user = params[:max_reservations_per_user]
 	tool.save
 	tool.set_field_data('model', params[:model])
 

--- a/views/admin/edit_tool.erb
+++ b/views/admin/edit_tool.erb
@@ -17,6 +17,15 @@
 		<label for="is-reservable">Requires Reservation?</label>
 	</div>
 	<div>
+	    <label for="max-reservations-per-user">User Reservation Limit</label><br>
+	    <select id="max-reservations-per-user" name="max_reservations_per_user">
+            <option value="">No Limit</option>
+            <% for i in 1..20 do
+                selected = tool.max_reservations_per_user == i ? ' selected=selected' : ''
+            %>
+            <option value="<%= i.to_s %>"<%= selected %>><%= i.to_s %></option>
+            <% end %>
+	    </select>
 		<label for="minutes-per-reservation">Minutes Per Reservation</label><br>
 		<input type="radio" name="time_slot_type" id="time-slot-type-exact" value="exact" <%= 'checked="checked"' if tool.time_slot_type == 'exact' || tool.time_slot_type.nil? %>>
 		<label for="time-slot-type-exact">Exactly:</label> <input type="number" name="minutes_per_reservation" id="minutes-per-reservation" value="<%= tool.minutes_per_reservation %>"><br><br>


### PR DESCRIPTION
Add new functionality for new resources DB column `max_reservations_per_user`:

* Added UI to resources (tool) admin page to set limit with values of no limit (NULL) or 1-20.
* Added frontend logic not to display resource (tool) as a reservation option if user is at or over limit.
* Added frontend logic in reservation form to check limit and display error to user that they are unable to reserve resource(tool) due to limit.

Note: related PR to add the DB column: https://git.unl.edu/iim/unl-resource-scheduler/merge_requests/6