### PR TITLE
Always allow tool to be viewable and only restrict reservation on reserve form.

### DIFF
--- a/views/reserve.erb
+++ b/views/reserve.erb
@@ -176,7 +176,11 @@ end %>
         </select>
         <% end %>
         <br><br>
+        <% if reservation.nil? && !@user.meets_resource_reservation_limit?(tool.id) %>
+        <p>You are at the user reservation limit of <%= tool.max_reservations_per_user.to_s%>.
+        <% else %>
         <button type="submit" class="dcf-btn dcf-btn-primary"><%= reservation.nil? ? 'Reserve' : 'Update' %></button>
+        <% end %>
     </div>
 </section>
 </form>

--- a/views/tools.erb
+++ b/views/tools.erb
@@ -22,7 +22,7 @@
             </td>
             <td class="table-actions">
                 <% if tool.is_reservable %>
-                    <a href="/tools/<%= tool.id %>/reserve/" class="dcf-btn dcf-btn-primary">Reserve Time</a>
+                    <a href="/tools/<%= tool.id %>/reserve/" class="dcf-btn dcf-btn-primary"><%= @user.meets_resource_reservation_limit?(tool.id) ? 'Reserve Time' : 'View Reservations' %></a>
                 <% else %>
                     Reservation not required
                 <% end %>


### PR DESCRIPTION
Changes to meet user request:

We need a tweak on this.

When members have made 2 reservations they can no longer see the equipment on their list of available equipment and therefore cannot check and see if there are open times in which they can simply show up at the studio to use it if no one has it reserved.

Can we change this so they can still see the equipment on their approved list but not make more than 2 reservations? It currently works this way when they try to make 2 reservations in a day on the same piece of equipment, which has been in place before you added this new restriction.


