### PR TITLE
Add reservation checking to event mgt when reserving tools

### DIFF
--- a/routes/admin/events.rb
+++ b/routes/admin/events.rb
@@ -222,7 +222,7 @@ post '/admin/events/:event_id/edit/?' do
             if event.start_time.in_time_zone < reservation.end_time.in_time_zone && reservation.start_time.in_time_zone < event.end_time.in_time_zone
                 # reset event times since reservation failed
                 event.update(start_time: original_event_start_time, end_time: original_event_end_time)
-j
+
                 # show error and display event form
                 flash :alert, "Tool is being used.", "Sorry, that tool is reserved during that time period. Please try different day or time."
                 redirect back

--- a/routes/tools.rb
+++ b/routes/tools.rb
@@ -363,9 +363,7 @@ post '/tools/:resource_id/reserve/?' do
 	# check for possible other reservations during this time period
 	other_reservations = Reservation.where(:resource_id => params[:resource_id]).in_day(date).all
 	other_reservations.each do |reservation|
-		if (start_time >= reservation.start_time && start_time < reservation.end_time) ||
-				(end_time > reservation.start_time && end_time <= reservation.end_time) ||
-				(start_time < reservation.start_time && end_time > reservation.end_time)
+		if start_time < reservation.end_time && reservation.start_time < end_time
 			flash :alert, "Tool is being used.", "Sorry, that tool is reserved during that time period. Please try another time slot."
 			redirect back
 		elsif reservation.user_id == @user.id
@@ -467,9 +465,7 @@ post '/tools/:resource_id/edit_reservation/:reservation_id/?' do
 	# check for possible other reservations during this time period
 	other_reservations = Reservation.where(:resource_id => params[:resource_id]).where.not(:id => reservation.id).in_day(date).all
 	other_reservations.each do |reservation|
-		if (start_time >= reservation.start_time && start_time < reservation.end_time) ||
-				(end_time >= reservation.start_time && end_time < reservation.end_time) ||
-				(start_time < reservation.start_time && end_time > reservation.end_time)
+		if start_time < reservation.end_time && reservation.start_time < end_time
 			flash :alert, "Tool is being used.", "Sorry, that tool is reserved during that time period. Please try another time slot."
 			redirect back
 		elsif reservation.user_id == @user.id


### PR DESCRIPTION
Addresses bug for https://support.nebraska.edu/footprints/servicedesk/application.html#runtimecontainer/view/workspace/18761/11916

Updates include:
* Adding reservation validation when creating/updating an event with tool reservation.
* Added sort of tool options to reserve from event create/update form.
* Simplified tool reservation overlapping check
