### PR TITLE
Move scheduler code to crontab for better performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,13 @@ Use this command to kill the process ID
 ```
 sudo -u innovationstudio kill -9 pid
 ```
+
+CRON
+====
+```
+0 12 * * * ruby ././scripts/email_expiring_users.rb
+0 12 * * * ruby ././scripts/email_unconfirmed_trainers.rb
+0 22 * * * ruby ././scripts/email_expiring_users_vehicle_update.rb
+
+#@reboot /var/www/html/innovationstudio-manager.unl.edu/startup.sh
+```

--- a/config/initializers/scheduler.rb
+++ b/config/initializers/scheduler.rb
@@ -1,21 +1,21 @@
 require 'highlander'    # prevents scheduler from running more than once
-require 'rufus-scheduler'
+# require 'rufus-scheduler'
 
-scheduler = Rufus::Scheduler::singleton
+# scheduler = Rufus::Scheduler::singleton
 
-scheduler.cron '0 12 * * * America/Chicago' do    # Every day at 12 pm Chicago time
-    if Time.new.hour == 12
-        system("ruby ././scripts/email_expiring_users.rb")
-        system("ruby ././scripts/email_unconfirmed_trainers.rb")
-    end
-end
+# scheduler.cron '0 12 * * * America/Chicago' do    # Every day at 12 pm Chicago time
+#     if Time.new.hour == 12
+#         system("ruby ././scripts/email_expiring_users.rb")
+#         system("ruby ././scripts/email_unconfirmed_trainers.rb")
+#     end
+# end
 
-scheduler.cron '0 22 * * * America/Chicago' do    # Every day at 10 pm Chicago time
-    if Time.new.hour == 22
-        system("ruby ././scripts/email_expiring_users_vehicle_update.rb")
-    end
-end
+# scheduler.cron '0 22 * * * America/Chicago' do    # Every day at 10 pm Chicago time
+#     if Time.new.hour == 22
+#         system("ruby ././scripts/email_expiring_users_vehicle_update.rb")
+#     end
+# end
 
-# prevents scheduler from exiting
-while 1 do
-end
+# # prevents scheduler from exiting
+# while 1 do
+# end


### PR DESCRIPTION
We are having issues with resources due to the `while 1` loop in the scheduler. Moving these scheduled tasks to the linux crontab will increase performance.