### PR TITLE
remove permissions attached to trainer status

### DIFF
--- a/models/user.rb
+++ b/models/user.rb
@@ -131,17 +131,11 @@ class User < ActiveRecord::Base
 
   def make_trainer_status
     self.is_trainer = 1
-    unless self.has_permission?(Permission::EVENTS_ADMIN_READ_ONLY)
-      self.permissions << Permission.find(Permission::EVENTS_ADMIN_READ_ONLY)
-    end
     self.save
   end
 
   def remove_trainer_status
     self.is_trainer = 0
-    unless !self.has_permission?(Permission::EVENTS_ADMIN_READ_ONLY)
-      self.permissions.delete(Permission::EVENTS_ADMIN_READ_ONLY)
-    end
     self.save
   end
 


### PR DESCRIPTION
There was some limitations and confusion caused by this so it was determined that this would be the best course of action