### PR TITLE
Announcements visible before login

### DIFF
--- a/routes/api.rb
+++ b/routes/api.rb
@@ -1,0 +1,12 @@
+require 'models/announcements'
+
+get '/api/announcements/?' do
+    announcement = Announcements.first
+
+    content_type :json
+    if announcement
+        { has_announcement: true, header: announcement.header, body: announcement.text }.to_json
+    else
+        { has_announcement: false, header: "", body: "" }.to_json
+    end
+end

--- a/views/auto_updating_announcement.erb
+++ b/views/auto_updating_announcement.erb
@@ -1,0 +1,57 @@
+<div id="announcement-notice-container" class="dcf-d-none">
+    <div id="announcement-notice" class="dcf-notice dcf-notice-info" data-no-close-button="true" hidden>
+    <h2><span id="announcement-header"></span></h2>
+    <div><span id="announcement-body"></span></div>
+    </div>
+</div>
+
+<script>
+    const announcement_notice_container = document.getElementById('announcement-notice-container');
+    const announcement_notice = document.getElementById('announcement-notice');
+    const announcement_url = "/api/announcements/";
+    const announcement_refresh_rate_ms = 30 * 1000;
+
+    async function fetch_notice() {
+            const announcement_notice_header = document.getElementById('announcement-header');
+            const announcement_notice_body = document.getElementById('announcement-body');
+        try {
+            const response = await fetch(announcement_url);
+            if (!response.ok) { console.err('Could Not Get Announcements'); return;}
+
+            const announcement_json = await response.json();
+            if ( !('has_announcement' in announcement_json && 'header' in announcement_json && 'body' in announcement_json)){
+                console.error('Bad Announcement JSON');
+                return;
+            }
+            if (
+                typeof announcement_json['has_announcement'] !== "boolean" ||
+                typeof announcement_json['header'] !== "string" ||
+                typeof announcement_json['body'] !== "string"
+            ) {
+                console.error('Bad Announcement JSON data');
+                return;
+            }
+
+            if (announcement_json['has_announcement'] === true) {
+                announcement_notice_container.classList.remove('dcf-d-none');
+                announcement_notice_header.innerText = announcement_json['header'];
+                announcement_notice_body.innerHTML = announcement_json['body'];
+            } else {
+                announcement_notice_container.classList.add('dcf-d-none');
+            }
+
+        } catch(err) {
+            console.error(err);
+        }
+    }
+
+    window.addEventListener('inlineJSReady', function() {
+        let check_interval = setInterval(() => {
+            if (announcement_notice.classList.contains('dcf-notice-initialized')) {
+                clearInterval(check_interval);
+                setInterval(fetch_notice, announcement_refresh_rate_ms);
+                fetch_notice();
+            }
+        }, 200);
+    }, false);
+</script>

--- a/views/check_in.erb
+++ b/views/check_in.erb
@@ -1,3 +1,4 @@
+<%= erb :auto_updating_announcement %>
 
 <h1 class="dcf-txt-h3">Check-In</h1>
 

--- a/views/check_in_login.erb
+++ b/views/check_in_login.erb
@@ -1,3 +1,5 @@
+<%= erb :auto_updating_announcement %>
+
 <h1 class="dcf-txt-h3">Check-In</h1>
 
 <form class="dcf-form" id="login" action="" method="POST">

--- a/views/login.erb
+++ b/views/login.erb
@@ -1,3 +1,5 @@
+<%= erb :auto_updating_announcement %>
+
 <h1 class="dcf-txt-h3">Login</h1>
 
 <form class="dcf-form" id="login" action="" method="POST">


### PR DESCRIPTION
Had some people requesting for announcements to be visible on the login page. So if someone checks in they will see that announcement.

I made an API for getting the announcement and I creating a way for the notice to update every 30 seconds. Not sure how the check in page works on their end but if it sits there without refreshing then this will still allow them to get the current announcement.